### PR TITLE
test(tox): do not install in develop mode

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,6 @@ score = no
 envlist = py38, py39, py310, pypy3, pyston3
 skip_missing_interpreters = true
 [testenv]
-usedevelop = true
 deps = -rrequirements-test.txt
 extras = examples
 commands =


### PR DESCRIPTION
Not sure why this was added in the first place. Conceptually better to
not do that, but to use regular install instead.