### PR TITLE
test(pytest-asyncio): upgrade to and adjust for >=0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@ requires = ["setuptools >=42", "wheel"]
 target-version = ["py38", "py39", "py310"]
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 filterwarnings = ["error"]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 pytest >=6
-pytest-asyncio
+pytest-asyncio >=0.17
 pytest-vcr
 # See note in test_pytekukko.vcr_config
 vcrpy ==4.1.1

--- a/tests/test_pytekukko.py
+++ b/tests/test_pytekukko.py
@@ -83,7 +83,6 @@ async def fixture_client() -> Pytekukko:
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.vcr
 async def test_login(client: Pytekukko) -> None:
     """Test login."""
@@ -92,7 +91,6 @@ async def test_login(client: Pytekukko) -> None:
     assert result
 
 
-@pytest.mark.asyncio
 @pytest.mark.vcr
 async def test_logout(client: Pytekukko) -> None:
     """Test logout."""
@@ -102,7 +100,6 @@ async def test_logout(client: Pytekukko) -> None:
     # No exception counts as success here
 
 
-@pytest.mark.asyncio
 @pytest.mark.vcr
 async def test_get_collection_schedule(client: Pytekukko) -> None:
     """Test getting collection schedule."""
@@ -114,7 +111,6 @@ async def test_get_collection_schedule(client: Pytekukko) -> None:
     assert all(isinstance(date, datetime.date) for date in dates)
 
 
-@pytest.mark.asyncio
 @pytest.mark.vcr
 async def test_get_invoice_headers(client: Pytekukko) -> None:
     """Test getting invoice headers."""


### PR DESCRIPTION
0.17 introduced the concept of `asyncio_mode` and added a deprecation
warning if it's not set. Use `auto` to reduce number of needed
decorators and to avoid the warning.

https://github.com/pytest-dev/pytest-asyncio/blob/dab3b5184c0bdd0bd93dddeb6968de7f565fb8db/README.rst#modes