### PR TITLE
chore(pylint): replace strict-informational plugin with `fail-on=I`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ load-plugins = [
   "pylint.extensions.overlapping_exceptions",
   "pylint.extensions.private_import",
   "pylint.extensions.redefined_loop_name",
-  "pylint_strict_informational",
 ]
 persistent = false
 py-version = "3.8"
+fail-on = ["I"]
 
 [tool.pylint."messages control"]
 disable = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,5 @@ isort ==5.10.1
 mypy ==0.942
 
 pylint ==2.14.3
-pylint-strict-informational ==0.1
 
 tox ~=3.14


### PR DESCRIPTION
`fail-on` is available since pylint 2.9.0.