### PR TITLE
test(py311): remove no longer needed yarl and frozenlist "no extensions"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,6 @@ commands =
 setenv =
   # https://github.com/aio-libs/aiohttp/issues/6600
   AIOHTTP_NO_EXTENSIONS = 1
-  # https://github.com/aio-libs/yarl/issues/680
-  YARL_NO_EXTENSIONS = 1
-  # Similarly as for aiohttp and yarl
-  FROZENLIST_NO_EXTENSIONS = 1
   # https://github.com/aio-libs/aiohttp/pull/6708
   PYTEKUKKO_AIOHTTP_CGI_W = -W "default:'cgi' is deprecated:DeprecationWarning:aiohttp.helpers"
   # https://github.com/certifi/python-certifi/issues/170#issuecomment-952885966


### PR DESCRIPTION
Not bumping/marking any required versions for this, instead assuming setups running pre-release Python 3.11 are also installing new enough dependencies to go with that.