### PR TITLE
fix(dist): actually include `py.typed`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include CHANGELOG.md
+include src/pytekukko/py.typed
 recursive-include tests *.py *.yaml


### PR DESCRIPTION
Commit 134eec2b9990d06f24ab8af42f6372e55ecd9b73 did fix it originally, but 75b9735998f1d29f50b830d7d45ee1184cec8230 broke it again. It went unnoticed and got included in my local tests because there was stale `src/pytekukko.egg-info` from a previous fixed build around.

Re-fix by including in `MANIFEST.in` per
https://setuptools.pypa.io/en/stable/userguide/datafiles.html#include-package-data