### PR TITLE
ci(tox): do without tox-gh-actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,17 +84,20 @@ jobs:
           exit $rc
 
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12.0-alpha - 3.12"
-          - "pypy-3.9"
+        include:
+          - python-version: "3.9"
+            toxenv: py39
+          - python-version: "3.10"
+            toxenv: py310
+          - python-version: "3.11"
+            toxenv: py311
+          - python-version: "3.12.0-alpha - 3.12"
+            toxenv: py312
+          - python-version: "pypy-3.9"
+            toxenv: pypy3
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -110,10 +113,10 @@ jobs:
             ${{ hashFiles('pyproject.toml', 'requirements-test.txt') }}
       - name: Install dependencies
         run: |
-          python3 -m pip install tox-gh-actions
+          python3 -m pip install "$(grep ^tox requirements-dev.txt)"
       - name: Run tests
         run: |
-          tox --skip-missing-interpreters false
+          tox -e ${{ matrix.toxenv }} --skip-missing-interpreters false
         env:
           PYTEST_ADDOPTS: --vcr-record=none --color=yes
           TOX_TESTENV_PASSENV: PYTEST_ADDOPTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,11 +100,4 @@ commands =
   {envpython} -X dev -bb -W error -m pytekukko.examples.print_invoice_headers --help
   {envpython} -X dev -bb -W error -m pytekukko.examples.print_next_collections --help
   {envpython} -X dev -bb -W error -m pytekukko.examples.update_google_calendar --help
-[gh-actions]
-python =
-  3.9: py39
-  3.10: py310
-  3.11: py311
-  3.12: py312
-  pypy-3.9: pypy3
 """


### PR DESCRIPTION
tox envs need to be configured anyway even with tox-gh-actions, so we might as well configure them in the CI job matrix where they're better placed than in the global tox config when using tox-gh-actions.

Dropping dependency on tox-gh-actions results in more freedom with regards to tox versions.