### PR TITLE
ci(renovate): set ruff versioning back to pep440

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,7 +48,7 @@
     {
       "matchPackagePatterns": ["(^|/)ruff(-pre-commit)?$"],
       "groupName": "ruff",
-      "versioning": "semver"
+      "versioning": "pep440"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit 173d53458e885a4509da4cb9114f40221b888cee.

Renovate's semver does not seem to strip the `==` we have in the requirements-dev.txt version.