### PR TITLE
chore(lint): use codes with `noqa`

### DIFF
--- a/src/pytekukko/examples/__init__.py
+++ b/src/pytekukko/examples/__init__.py
@@ -73,10 +73,10 @@ def example_argparser(description: str) -> ArgumentParser:
 def example_client(args: Namespace) -> tuple[Pytekukko, CookieJar, Optional[Path]]:
     """Set up example client."""
     if not args.customer_number:
-        print("customer number required", file=sys.stderr)  # noqa: print-found
+        print("customer number required", file=sys.stderr)  # noqa: T201
         sys.exit(2)
     if not args.password:
-        print("password required", file=sys.stderr)  # noqa: print-found
+        print("password required", file=sys.stderr)  # noqa: T201
         sys.exit(2)
     cookie_jar = CookieJar()
     cookie_jar_path = None

--- a/src/pytekukko/examples/print_collection_schedules.py
+++ b/src/pytekukko/examples/print_collection_schedules.py
@@ -28,7 +28,7 @@ async def run_example() -> None:
         if not cookie_jar_path:
             await client.logout()
 
-    print(json.dumps(data))  # noqa: print-found
+    print(json.dumps(data))  # noqa: T201
 
     if cookie_jar_path:
         cookie_jar.save(cookie_jar_path)

--- a/src/pytekukko/examples/print_invoice_headers.py
+++ b/src/pytekukko/examples/print_invoice_headers.py
@@ -27,7 +27,7 @@ async def run_example() -> None:
         if not cookie_jar_path:
             await client.logout()
 
-    print(json.dumps(data))  # noqa: print-found
+    print(json.dumps(data))  # noqa: T201
 
     if cookie_jar_path:
         cookie_jar.save(cookie_jar_path)

--- a/src/pytekukko/examples/print_next_collections.py
+++ b/src/pytekukko/examples/print_next_collections.py
@@ -27,7 +27,7 @@ async def run_example() -> None:
         if not cookie_jar_path:
             await client.logout()
 
-    print(json.dumps(data))  # noqa: print-found
+    print(json.dumps(data))  # noqa: T201
 
     if cookie_jar_path:
         cookie_jar.save(cookie_jar_path)

--- a/src/pytekukko/examples/update_google_calendar.py
+++ b/src/pytekukko/examples/update_google_calendar.py
@@ -165,7 +165,7 @@ async def run_example() -> None:
     args = argparser.parse_args()
 
     if not args.google_calendar_id:
-        print("Google calendar id required", file=sys.stderr)  # noqa: print-found
+        print("Google calendar id required", file=sys.stderr)  # noqa: T201
         sys.exit(2)
 
     client, cookie_jar, cookie_jar_path = example_client(args)


### PR DESCRIPTION
At least for now, for some compatibility with original non-ruff implementations.