### PR TITLE
ci(renovate): use regex manager instead of a pip requirements hack

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,15 @@
   "semanticCommits": "enabled",
   "commitMessageTopic": "{{depName}}",
   "pip_requirements": {
-    "fileMatch": [
-      "(^|/)(requirements[\\w-]*\\.txt|\\.pre-commit-config\\.yaml)$"
-    ]
+    "fileMatch": ["(^|/)requirements[\\w-]*\\.txt$"]
   },
+  "regexManagers": [
+    {
+      "fileMatch": ["^\\.pre-commit-config\\.yaml$"],
+      "matchStrings": ["(?<depName>[\\w-]+)(?<currentValue>==[a-z0-9.]+)"],
+      "datasourceTemplate": "pypi"
+    }
+  ],
   "packageRules": [
     {
       "matchFiles": ["requirements-test.txt"],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,7 @@ repos:
         name: mypy
         language: python
         additional_dependencies:
-          - #
-            venv-run ==0.1.2
+          - venv-run==0.1.2
         entry: venv-run mypy .
         types: [python]
         pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Typing :: Typed",
 ]
-dependencies = ["aiohttp ~=3.4"]
+dependencies = ["aiohttp~=3.4"]
 
 [project.optional-dependencies]
-examples = ["python-dotenv ~=0.10", "google-api-python-client ~=2.0,>=2.0.2"]
+examples = ["python-dotenv~=0.10", "google-api-python-client~=2.0,>=2.0.2"]
 
 [project.scripts]
 pytekukko-collection-schedules = "pytekukko.examples.print_collection_schedules:main [examples]"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -e .[examples]
 -r requirements-test.txt
 
-black ==23.1.0
-mypy ==1.0.1
-ruff ==0.0.252
+black==23.1.0
+mypy==1.0.1
 nox
+ruff==0.0.252

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,11 @@
-pytest >=6
-pytest-asyncio >=0.17
-pytest-vcr
-vcrpy ==4.2.1
-python-dotenv ~=0.10
+pytest>=6
+  pytest-asyncio>=0.17
+  pytest-vcr
+  vcrpy==4.2.1
+python-dotenv~=0.10
 
 # https://github.com/aio-libs/aiohttp/issues/6600
 # https://github.com/aio-libs/aiohttp/pull/6708
-aiohttp ~=3.4,>=3.8.2; python_version>='3.11'
+aiohttp~=3.4,>=3.8.2;python_version>='3.11'
 # https://github.com/certifi/python-certifi/pull/199
-certifi >=2022.6.15.1; python_version>='3.11'
+certifi>=2022.6.15.1;python_version>='3.11'


### PR DESCRIPTION
For updating additional PyPI dependencies in `.pre-commit-config.yaml` (just one remains though).

Allows formatting versioned dependencies without whitespace hacks there; take advantage of it and remove the weirdness everywhere.