### PR TITLE
test(nox): build with aiohttp, frozenlist and yarl extensions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,5 @@
 """nox config for pytekukko."""
 
-from typing import cast
-
 import nox
 
 nox.options.error_on_external_run = True
@@ -10,12 +8,6 @@ nox.options.error_on_external_run = True
 @nox.session(python=[f"{py}3.{x}" for py in ("", "pypy") for x in range(9, 13)])
 def test(session: nox.Session) -> None:
     """Run tests."""
-    if int(cast(str, session.python).rpartition(".")[2]) >= 12:  # noqa: PLR2004
-        session.env.update(
-            AIOHTTP_NO_EXTENSIONS="1",
-            FROZENLIST_NO_EXTENSIONS="1",
-            YARL_NO_EXTENSIONS="1",
-        )
     session.install(".[examples]", "-r", "requirements/test-requirements.txt")
 
     prefix = "python3 -X dev -bb"


### PR DESCRIPTION
Disabling the extensions seems no longer needed as of Python 3.12.0b1.