### PR TITLE
test(nox): skip aiohttp and frozenlist native builds with Python 3.12

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,7 @@
 """nox config for pytekukko."""
 
+from typing import cast
+
 import nox
 
 nox.options.error_on_external_run = True
@@ -8,6 +10,11 @@ nox.options.error_on_external_run = True
 @nox.session(python=[f"{py}3.{x}" for py in ("", "pypy") for x in range(9, 13)])
 def test(session: nox.Session) -> None:
     """Run tests."""
+    if int(cast(str, session.python).rpartition(".")[2]) >= 12:  # noqa: PLR2004
+        session.env.update(
+            AIOHTTP_NO_EXTENSIONS="1",
+            FROZENLIST_NO_EXTENSIONS="1",
+        )
     session.install(".[examples]", "-r", "requirements/test-requirements.txt")
 
     prefix = "python3 -X dev -bb"


### PR DESCRIPTION
Seemingly necessary again as of Python 3.12.0b2.