### PR TITLE
refactor: drop Python 3.9 support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,11 +42,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12.0-alpha - 3.12"
-          - "pypy-3.9"
           - "pypy-3.10"
     steps:
       - uses: actions/checkout@v3

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ import nox
 nox.options.error_on_external_run = True
 
 
-@nox.session(python=[f"{py}3.{x}" for py in ("", "pypy") for x in range(9, 13)])
+@nox.session(python=[f"{py}3.{x}" for py in ("", "pypy") for x in range(10, 13)])
 def test(session: nox.Session) -> None:
     """Run tests."""
     if int(cast(str, session.python).rpartition(".")[2]) >= 12:  # noqa: PLR2004

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pytekukko"
 version = "0.13.0"
 description = "Jätekukko Omakukko API client"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Ville Skyttä", email = "ville.skytta@iki.fi" }]
 classifiers = [
@@ -57,7 +57,7 @@ src = ["src", "tests"]
 "tests/*.py" = ["S101"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 enable_error_code = "ignore-without-code,redundant-self,truthy-iterable"
 strict = true

--- a/src/pytekukko/__init__.py
+++ b/src/pytekukko/__init__.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from datetime import date
 from datetime import datetime as dt
 from http import HTTPStatus
-from typing import Any, Union, cast
+from typing import Any, cast
 from urllib.parse import urljoin
 from zoneinfo import ZoneInfo
 
@@ -57,12 +57,12 @@ class Pytekukko:
             url=url,
             params=params,
         )
-        if not isinstance(response_data, (list, tuple)):
+        if not isinstance(response_data, list | tuple):
             raise UnexpectedResponseStructureError(response_data)
 
         return [Service(raw_data=_unmarshal(service)) for service in response_data]
 
-    async def get_collection_schedule(self, what: Union[Service, int]) -> list[date]:
+    async def get_collection_schedule(self, what: Service | int) -> list[date]:
         """Get collection schedule for a service.
 
         :param what: the service or a "pos" value of one to get schedule for
@@ -91,7 +91,7 @@ class Pytekukko:
             url=url,
             params=params,
         )
-        if not isinstance(response_data, (list, tuple)):
+        if not isinstance(response_data, list | tuple):
             raise UnexpectedResponseStructureError(response_data)
 
         return [

--- a/src/pytekukko/examples/__init__.py
+++ b/src/pytekukko/examples/__init__.py
@@ -4,7 +4,6 @@ import os
 import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Optional
 
 from aiohttp import ClientSession, CookieJar
 from dotenv import find_dotenv, load_dotenv
@@ -16,8 +15,8 @@ def arg_environ_default(
     key: str,
     *,
     optional: bool = False,
-    fallback: Optional[str] = None,
-) -> dict[str, Optional[str]]:
+    fallback: str | None = None,
+) -> dict[str, str | None]:
     """Get kwargs for environment backed argument addition."""
     help_text = f"default: ${key} from environment"
     if optional:
@@ -70,7 +69,7 @@ def example_argparser(description: str) -> ArgumentParser:
     return argparser
 
 
-def example_client(args: Namespace) -> tuple[Pytekukko, CookieJar, Optional[Path]]:
+def example_client(args: Namespace) -> tuple[Pytekukko, CookieJar, Path | None]:
     """Set up example client."""
     if not args.customer_number:
         print("customer number required", file=sys.stderr)  # noqa: T201

--- a/src/pytekukko/models.py
+++ b/src/pytekukko/models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 
 @dataclass
@@ -29,7 +29,7 @@ class Service:
         return cast(int, self.raw_data["ASTPos"])
 
     @property
-    def next_collection(self) -> Optional[date]:
+    def next_collection(self) -> date | None:
         """Get next collection date.
 
         :returns: Next collection date, None if not applicable for the service.


### PR DESCRIPTION
Dropped in current HA a while back, and Debian Bookworm comes with 3.11.