### PR TITLE
ci(release): drop separate setup-python action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.release_please.outputs.sha }}
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
       - name: Create release assets
         run: |
           set -euxo pipefail


### PR DESCRIPTION
The default Python for an up to date `ubuntu-latest` image should be a good enough, maintenance free default in the usual case.

https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md