### PR TITLE
ci: switch release-please action to googleapis one, upgrade to 4.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release_please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         id: release_please
         with:
           config-file: .github/release-please-config.json


### PR DESCRIPTION
The google-github-actions one is deprecated and archived.