### PR TITLE
chore(ci): revert renovate committed config attempts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,11 +16,6 @@
   "commitMessageTopic": "{{depName}}",
   "packageRules": [
     {
-      "matchDepNames": ["committed"],
-      "overrideDatasource": "github-releases",
-      "overridePackageName": "crate-ci/committed"
-    },
-    {
       "matchFileNames": [
         "requirements/test-requirements.txt"
       ],

--- a/.github/workflows/update-tools.yaml
+++ b/.github/workflows/update-tools.yaml
@@ -1,0 +1,21 @@
+name: Tooling updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "42 0 * * 6"
+
+jobs:
+  update-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
+      - name: Check for and prepare updates
+        run: mise upgrade --bump
+      - uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
+        with:
+          token: ${{ secrets.TOOLS_UPDATE_TOKEN }}
+          push-to-fork: bot-${{ github.repository }}
+          commit-message: "chore: automated tools update"
+          title: "chore: tooling updates"


### PR DESCRIPTION
Does not appear to work after all on some quick tries, let it be for now.

This reverts commit 3aeb99b8f69a4ac1fe755350c87fd0cc416ebf7e. This reverts commit fe80736874338b3b8077bd0b75d5ed8a54d18c8f.