### PR TITLE
chore(lefthook): run ruff through uv

### DIFF
--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -12,9 +12,9 @@ pre-commit:
             group:
               jobs:
                 - name: ruff-check
-                  run: mise exec -- ruff check --force-exclude --fix {staged_files}
+                  run: uv run ruff check --force-exclude --fix {staged_files}
                 - name: ruff-format
-                  run: mise exec -- ruff format --force-exclude {staged_files}
+                  run: uv run ruff format --force-exclude {staged_files}
                 - name: mypy
                   run: uv run mypy .
     - name: typos


### PR DESCRIPTION
As we install it with uv too (not mise).