### PR TITLE
chore(ruff): run and install with mise instead of uv

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -2,6 +2,7 @@
 committed = "1.1.5"
 dprint = "0.48.0"
 lefthook = "latest"
+ruff = "0.9.4"
 typos = "1.29.5"
 
 [env]

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -12,9 +12,9 @@ pre-commit:
             group:
               jobs:
                 - name: ruff-check
-                  run: uv run ruff check --force-exclude --fix {staged_files}
+                  run: mise exec -- ruff check --force-exclude --fix {staged_files}
                 - name: ruff-format
-                  run: uv run ruff format --force-exclude {staged_files}
+                  run: mise exec -- ruff format --force-exclude {staged_files}
                 - name: mypy
                   run: uv run mypy .
     - name: typos

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -3,4 +3,3 @@
 
 mypy==1.8.0
 nox[uv]
-ruff==0.9.3


### PR DESCRIPTION
With mise we have better control over the version of ruff installed when done through lefthook. A stray ruff install that precedes the mise installed one in PATH can still wreak havoc, though.