### PR TITLE
chore(deps): require pytest-asyncio >=0.25

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,11 +12,6 @@ def test(session: nox.Session) -> None:
 
     known_deprecations = [
         "-W",
-        (  # https://github.com/pytest-dev/pytest-asyncio/issues/929, slated for 1.0
-            "default:'asyncio.iscoroutinefunction':"
-            "DeprecationWarning:pytest_asyncio.plugin"
-        ),
-        "-W",
         (  # https://github.com/pytest-dev/pytest-asyncio/issues/1025
             r"default:'asyncio.get_event_loop_policy':"
             "DeprecationWarning:pytest_asyncio.plugin"

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,5 +1,5 @@
 pytest>=6
-  pytest-asyncio>=0.17
+  pytest-asyncio>=0.25
   pytest-vcr
   vcrpy==7.0.0
 python-dotenv>=0.10,<2


### PR DESCRIPTION
To avoid having to exclude a deprecation warning.