### PR TITLE
chore(lefthook): tweak commit lint job name

### DIFF
--- a/.config/lefthook.yaml
+++ b/.config/lefthook.yaml
@@ -32,7 +32,7 @@ commit-msg:
     committed:
       run: mise exec -- committed --config .config/committed.toml --fixup --wip --commit-file "{1}"
 
-commit-msgs-on-pr-branch:
+commits-on-pr-branch:
   commands:
     committed:
       run: mise exec -- committed --config .config/committed.toml -vv --no-merge-commit HEAD~..HEAD^2

--- a/.github/workflows/lint-commits.yaml
+++ b/.github/workflows/lint-commits.yaml
@@ -20,4 +20,4 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
-      - run: lefthook run commit-msgs-on-pr-branch --no-tty
+      - run: lefthook run commits-on-pr-branch --no-tty


### PR DESCRIPTION
Committed potentially lints other aspects of commits besides just the message.