### PR TITLE
chore(ci): separate dist build from publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,14 +24,13 @@ jobs:
       release-created: ${{ steps.release-please.outputs.release_created }}
       sha: ${{ steps.release-please.outputs.sha }}
 
-  pypi-publish:
-    name: PyPI publish
+  build-dist:
+    name: Build dists
     runs-on: ubuntu-latest
     needs: release-please
     if: needs.release-please.outputs.release-created
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -46,4 +45,21 @@ jobs:
           uv pip install --upgrade build
           uv run python3 -m build
           ls dist
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-dist
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5.0.0
+        with:
+          name: dist
+          path: dist/
+      - run: ls dist
       - uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11


### PR DESCRIPTION
For more granular token permissions.