### PR TITLE
chore(ci): remove LEFTHOOK_QUIET env

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: true
-      LEFTHOOK_QUIET: meta,execution
     permissions:
       contents: read
     steps:

--- a/.github/workflows/lint-commits.yaml
+++ b/.github/workflows/lint-commits.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: true
-      LEFTHOOK_QUIET: meta,execution
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
It no longer exists in lefthook 2. I suppose the default output is not that bad anyway, so let's not bother replacing with LEFTHOOK_OUTPUT at least for now.