### PR TITLE
test(deps): pin aiohttp to < 3.14 for vcrpy compat

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,5 +2,6 @@ pytest>=6
   pytest-asyncio>=0.25
   pytest-recording
   vcrpy==8.1.1
+  aiohttp<3.14 # https://github.com/kevin1024/vcrpy/issues/995, vcrpy > 8.1.1
 python-dotenv>=0.10,<2
 shtab


### PR DESCRIPTION
Likely to be fixed in vcrpy > 8.1.1, https://github.com/kevin1024/vcrpy/issues/995