### PR TITLE
docs(README): remove Python 3 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # pytekukko -- Jätekukko Omakukko API client
 
-[![Python versions](https://img.shields.io/pypi/pyversions/pytekukko.svg)](https://pypi.org/project/pytekukko/)
 [![PyPI version](https://badge.fury.io/py/pytekukko.svg)](https://badge.fury.io/py/pytekukko)
 [![CI status](https://github.com/scop/pytekukko/actions/workflows/test.yaml/badge.svg)](https://github.com/scop/pytekukko/actions/workflows/test.yaml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/scop/pytekukko/badge)](https://scorecard.dev/viewer/?uri=github.com%2Fscop%2Fpytekukko)


### PR DESCRIPTION
It's the standard these days.