### PR TITLE
chore(emacs): remove settings

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,0 @@
-;;; Directory Local Variables
-;;; For more information see (info "(emacs) Directory Variables")
-
-((python-mode
-  (mode . ruff-format-on-save)))


### PR DESCRIPTION
ruff-format-on-save-mode might not be installed, and other modes such as apheleia-mode work just as fine if not better.

Whether to format on save or not is also a user preference that does not need to be forced anyway.